### PR TITLE
Fix Misc -> Follow/* and first frame issues

### DIFF
--- a/web/js/webshark.js
+++ b/web/js/webshark.js
@@ -625,7 +625,8 @@ function webshark_load_frame(framenum, scroll_to, cols)
 	var ref_framenum = g_webshark.getRefFrame(framenum);
 	if (ref_framenum)
 		load_req['ref_frame'] = ref_framenum;
-	load_req['prev_frame'] = framenum - 1;   /* TODO */
+	if (framenum > 1)
+		load_req['prev_frame'] = framenum - 1;   /* TODO */
 
 	webshark_json_get(load_req,
 		function(data)
@@ -651,7 +652,7 @@ function webshark_load_frame(framenum, scroll_to, cols)
 
 			if (fol)
 			{
-				for (var i = 1; i < fol.length; i++)
+				for (var i = 0; i < fol.length; i++)
 				{
 					var it = document.getElementById('menu_tap_follow:' + fol[i][0]);
 


### PR DESCRIPTION
I think both of these may have been caused by API changes:

 * Follow/TCP wasn't displayed b/c it is fol[0], and we started at 1
 * First frame was unselectable b/c backend doesn't like prev_frame=0

Also, I'm not sure on the semantics of prev_frame (is that the previous displayed in the list, or the previously-selected frame?).  The [sharkd wiki](https://wiki.wireshark.org/sharkd-Request-Syntax.md) seems to imply that it doesn't work, although that wiki hasn't been updated in a long time.  Maybe better to just remove it?