### PR TITLE
Set ownership on /captures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt update \
     && apt install -y git libglib2.0-0 speex libspeex1 libspeexdsp1 libc-ares2 libxml2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /captures /usr/local/bin /usr/local/share/wireshark/
+RUN mkdir -p /captures /usr/local/bin /usr/local/share/wireshark/ \
+    && chown -R node: /captures
 
 COPY --from=intermediate /usr/src/wireshark/build/run/sharkd /usr/local/bin/sharkd
 COPY --from=intermediate /usr/src/wireshark/build/run/colorfilters /usr/local/share/wireshark/colorfilters
@@ -39,7 +40,6 @@ ENV SHARKD_SOCKET=/captures/sharkd.sock
 COPY --chown=node . /usr/src/node-webshark
 COPY --from=intermediate /usr/src/web /usr/src/node-webshark/web
 
-USER node
 VOLUME /captures
 
 WORKDIR /usr/src/node-webshark/api

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,12 @@
 # sharkd daemon fails to start if the socket already exists
 rm "$SHARKD_SOCKET"
 
-exec npm start
+dir_owner=$(stat -c "%U:%G" "${CAPTURES_PATH}")
+
+if [ "x${dir_owner}" = "xroot:root" ]; then
+    # assume CAPTURES_PATH owned by root:root is unintentional
+    # (probably created by docker-compose)
+    chown node: "${CAPTURES_PATH}"
+fi
+
+exec su node -c "npm start"


### PR DESCRIPTION
Set inital ownership on /captures in dockerfile. Run entrypoint script as root so that it can change `root:root` ownership to `node:node` in the case of docker compose, then use `su` to drop back to the node user.

Fixes #36