### PR TITLE
Optimize socket read

### DIFF
--- a/api/custom_module/sharkd_dict.js
+++ b/api/custom_module/sharkd_dict.js
@@ -186,15 +186,6 @@ send_req = async function(request, sock) {
       return null;
     }
 
-    let data = '';
-    let chunk = await new_sock.read();
-
-    data += chunk;
-    while (_str_is_json(data) === false) {
-      chunk = await new_sock.read();
-      data += chunk;
-    }
-
     let result = await readAndParseSocket(new_sock);
 
     if ("result" in result) {

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,8 @@
     "glob-parent": "^6.0.2",
     "node-fetch": "^3.2.6",
     "promise-socket": "^7.0.0",
-    "yargs-parser": "^21.1.1"
+    "yargs-parser": "^21.1.1",
+    "JSONStream": "^1.3.5"
   },
   "devDependencies": {
     "tap": "^16.3.8"


### PR DESCRIPTION
Apologies for the oversight in my previous commit. I mistakenly left the old socket.read logic (`data += chunk; while (!_str_is_json(data)) { chunk = await new_sock.read(); data += chunk; }`) in the code. In this new commit, I have removed the outdated logic and replaced it with the new method `let result = await readAndParseSocket(new_sock);` to handle JSON parsing more efficiently. Sorry for any inconvenience caused.
